### PR TITLE
Enable typed app shell and add accelerator checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning, as far as it makes sense for a demo.
 
+## [Unreleased]
+### Added
+- Dokumenteret fælles "Accelerator & Udvikler"-tjekliste til produktion i `docs/accelerator-checklist.md`.
+
+### Changed
+- Delingslinks bruger nu stabile `#event:<id>`-URL’er i stedet for midlertidige snapshot-koder.
+- Lokal database starter tom uden demo-data for at understøtte produktion.
+- Fjernet `// @ts-nocheck` fra `flok-app.tsx`, typed hjælperfunktioner og komponenter samt aktiveret `npm run typecheck` i pipeline.
+
 ## [0.2.0] - 2025-08-29
 ### Added
 - Internal invitations: Send per‑friend invites in-app; recipients accept via Notifikationer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Tak fordi du vil hjælpe! Dette repo er en lille Vite + React app med Tailwind og en demo‑backend i `localStorage`.
+Tak fordi du vil hjælpe! Dette repo er en lille Vite + React app med Tailwind og lokal persistence i `localStorage`.
 
 ## Kom i gang
 - Node 18+

--- a/README.md
+++ b/README.md
@@ -37,20 +37,20 @@ PWA hurtigt (lokal test)
 Nye forbedringer
 - Ny gæste‑landing: Enkel forside for ikke‑loggede brugere med tre tydelige knapper: “Opret begivenhed” (primær), “Log ind som gæst” og “Log ind”. Navigation skjules her for at holde fokus.
 - Samlet samtale: “Opslag” og “Afstemninger” er samlet i fanen “Samtale”. “Chat”-kategorien er fjernet.
- - Deltag via kode: Knap i topbaren åbner felt til event‑ID, invitekode eller snapshot (s:...). Finder event og navigerer dertil.
+- Deltag via kode: Knap i topbaren åbner felt til event‑ID, invitekode eller direkte link og navigerer brugeren til begivenheden.
  - Børn for forældre: Tilføj/administrér børn på din profil og vælg dem direkte i RSVP‑panelet, når du svarer.
 - Deling: Korte links bruges ved kopiering og deling. Ekstra knapper til Facebook‑sharer, Messenger (kræver `VITE_FB_APP_ID`), SMS og WhatsApp. “Kopiér besked” kopierer hele invitationsteksten i ét klik.
 - Facebook på kort: Lille “Del via Facebook”‑knap direkte på eventkortene.
 - QR‑kode: I delingsdialogen kan du generere en QR‑kode for kort link eller eventkode, med mulighed for download og print.
 - Interne invitationer: Send invitationer direkte til venner i appen. Invitationer kan accepteres fra Notifikationer.
-- Kort delingslink: Del med et kort hash-link af formen `#s:<snapshot>` (importeres automatisk ved åbning).
+- Delingslink: Kopiér et stabilt link til `#event:<id>` for hurtig deling.
 - Del/Share: Web Share API med fallback til e-mail, mens “Kopiér tekst” bevarer ren kopi.
 - Opslag: Fastgjorte opslag vises øverst.
 - Hjem: Skift mellem “Kommende” og “Tidligere” events.
 - Værtstyring: Duplikér, arkivér eller slet begivenheder. Bedre billedkomprimering.
 - Modulær UI: Tailwind-stilklasser i `src/ui/styles.ts`. Genbrugelige hjælpefunktioner i `src/utils.ts` (med tests).
  - Invitationer: Eget modul i `src/modules/invitations.ts` med enhedstests.
- - Base64 utils: Sikker URL‑safe encoding/decoding uden deprecated API’er.
+- Delingshjælpere: `buildInviteUrl` genererer stabile `#event:<id>`-links til deling.
  - Feedback og tilgængelighed: Ikke‑blokkerende toasts (`ToastProvider`) med `aria-live`, let haptik (vibration) samt reduceret motion ved `prefers-reduced-motion`.
  - A11y‑småtterier: `aria-label` på ikonknapper (tema, notifikationer, log ind/ud, opret). Interaktive chips (børnevalg) har nu minimum 44×44 pt trykområde.
  - Bekræftelser: Egen `ConfirmProvider` med tilpasset modal og “Fortryd” via toast‑handling for destruktive valg (fx slet begivenhed, fjern ven, ryd notifikationer).
@@ -58,14 +58,14 @@ Nye forbedringer
 - Kontrast: Sekundær tekst og ringfarver justeret for bedre WCAG‑kontrast i lys/mørk tilstand.
 
 Deling og links (hurtigt overblik)
-- Kort link: `shortInviteUrl(ev)` genererer `/#s:<snapshot>` som virker uden backend (snapshot importeres ved åbning).
+- Link: `buildInviteUrl(ev)` genererer `/#event:<id>` så gæster kan åbne den konkrete begivenhed.
 - Facebook: Del via sharer på kort og i dialog.
 - Messenger: Understøttes via Facebook Dialog Send (kræver `VITE_FB_APP_ID`).
 - SMS/WhatsApp: Hurtig deling med forudfyldt tekst.
 - QR: QR‑kode for kort link eller eventkode kan vises, downloades som PNG og printes.
 
 Bemærk
-- Data gemmes i browseren. Ryd localStorage-nøglen `flok-db-v1` for at nulstille demo-data.
+- Data gemmes i browseren. Ryd localStorage-nøglen `flok-db-v1` for at nulstille din lokale database.
 - Notifikationer kræver tilladelse i browseren.
 - `flok-app.tsx` er en stor, genereret komponent. Den er bevidst udeladt fra ESLint og har `// @ts-nocheck` indtil gradvis udtrækning til moduler er færdig.
 

--- a/docs/accelerator-checklist.md
+++ b/docs/accelerator-checklist.md
@@ -1,0 +1,36 @@
+# Produktionsplan: Accelerator & Udvikler
+
+Denne tjekliste samler de faste håndtag vi skal dreje på for at gøre Flok klar til offentlig lancering. Brug den som fælles reference mellem udvikler (programmør) og accelerator (forretning/operation).
+
+## 1. Arkitektur & Teknik
+- [ ] Planlæg backend-løsning (managed Postgres + Node/Cloud Functions) og aftal ansvar for drift, sikkerhedspatches og backup.
+- [ ] Fastlæg API-kontrakter (events, brugere, invitationer, notifikationer). Udvikler udarbejder OpenAPI-spec og mock endpoints, accelerator godkender datafelter og compliance-krav (GDPR, opbevaringsperiode).
+- [ ] Definér miljøer: `dev`, `staging`, `produktion`. Accelerator stiller infrastruktur til rådighed, udvikler sætter CI/CD op til automatisk deploy.
+- [ ] Beslut identitetsløsning (Auth0, Cognito, Clerk, egen). Accelerator ejer leverandørvalg og budget, udvikler integrerer og migrerer temp logins til rigtige session tokens.
+
+## 2. Datakvalitet & Migration
+- [ ] Udarbejd plan for flytning af eksisterende localStorage-data til backend (engangsscript + brugernotifikation).
+- [ ] Definér dataopbevaring og slettepolitik. Accelerator tager stilling til retention, udvikler implementerer purge-jobs.
+- [ ] Sæt lognings- og monitoreringskrav (audit log, fejlrapportering, performance-målepunkter).
+
+## 3. Sikkerhed & Privatliv
+- [ ] Udfør threat-model workshop: hvilke angreb skal dækkes (brute-force, invitation guessing, CSRF, XSS).
+- [ ] Accelerator indkøber juridiske dokumenter (privatlivspolitik, databehandleraftale). Udvikler implementerer samtykke-flows og cookie-banner.
+- [ ] Fastlæg incident response-plan (kontaktliste, SLA for kritiske fejl, kommunikation til brugere).
+
+## 4. QA & Release-proces
+- [ ] Udvikler opsætter testpyramide: enhedstests (Vitest), komponenttests (React Testing Library), e2e (Playwright/Cypress).
+- [ ] Accelerator planlægger beta-program (målgruppe, feedback-kanaler, support SLA).
+- [ ] Opret release-checklist (funktionel test, regression, performancebudget, accessibility-audit). Begge parter signerer før “Go”.
+
+## 5. Drift & Support
+- [ ] Vælg overvågningsstack (Logtail/Datadog/Sentry) og definer alarmer for uptime, fejlrate, e-mail/SMS leveringsfejl.
+- [ ] Etabler supportkanaler (helpdesk, FAQ, statuspage). Accelerator bemander, udvikler leverer integrationer.
+- [ ] Plan for løbende optimering: kvartalsvise retros, roadmap-opdatering, budget for nye features.
+
+## Sådan bruger du dokumentet
+1. Gennemgå hver sektion sammen i sprint-planlægning.
+2. Tildel klare ejere (Accelerator vs. Udvikler) og deadlines.
+3. Opdater status ugentligt – dokumentet skal afspejle den aktuelle sandhed.
+
+Når punkterne er grønne, har vi både de tekniske og organisatoriske byggesten til en tryggere lancering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
         "@capacitor/ios": "^7.4.3",
         "framer-motion": "^11.3.31",
         "lucide-react": "^0.451.0",
-        "lz-string": "^1.5.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@capacitor/cli": "^7.4.3",
+        "@types/qrcode": "^1.5.5",
         "@types/react": "^18.3.8",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
@@ -1755,6 +1755,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.5.tgz",
+      "integrity": "sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
@@ -5072,14 +5082,6 @@
       "integrity": "sha512-OwQ3uljZLp2cerj8sboy5rnhtGTCl9UCJIhT1J85/yOuGVlEH+xaUPR7tvNdddPvmV5M5VLdr7cQuWE3hzA4jw==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@capacitor/ios": "^7.4.3",
     "framer-motion": "^11.3.31",
     "lucide-react": "^0.451.0",
-    "lz-string": "^1.5.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
@@ -37,6 +36,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react-swc": "^3.7.1",
     "autoprefixer": "^10.4.20",
+    "@types/qrcode": "^1.5.5",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.37.1",

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { encodeSnapshot, decodeSnapshot, toICS, fmtDateTimeRange, shortInviteUrl } from './utils';
+import { toICS, fmtDateTimeRange, buildInviteUrl } from './utils';
 
 describe('utils', () => {
   const sample = {
@@ -14,21 +14,6 @@ describe('utils', () => {
     cover: '',
   } as any;
 
-  it('encodes and decodes snapshot', () => {
-    const s = encodeSnapshot(sample);
-    expect(typeof s).toBe('string');
-    const decoded = decodeSnapshot(s);
-    expect(decoded.title).toBe(sample.title);
-    expect(decoded.address).toBe(sample.address);
-  });
-
-  it('handles unicode safely in snapshot', () => {
-    const u = { ...sample, title: 'ÆØÅ – Café “Smørrebrød” 🍰' } as any;
-    const enc = encodeSnapshot(u);
-    const dec = decodeSnapshot(enc);
-    expect(dec.title).toBe(u.title);
-  });
-
   it('creates valid ICS content', () => {
     const ics = toICS(sample);
     expect(ics).toContain('BEGIN:VCALENDAR');
@@ -41,9 +26,9 @@ describe('utils', () => {
     expect(typeof s).toBe('string');
   });
 
-  it('creates short link from snapshot', () => {
-    // window.location mocked by jsdom in Vitest
-    const url = shortInviteUrl(sample);
-    expect(url).toContain('#s:');
+  it('builds invite url with event id', () => {
+    const url = buildInviteUrl(sample);
+    expect(url).toContain('#event:');
+    expect(url.endsWith('#event:e1')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- remove the `// @ts-nocheck` escape from `flok-app.tsx` and add explicit Flok types for notifications, conversations, profiles, and event creation flows
- add missing TypeScript definitions and state helpers so New Event and Manage Event forms keep typed repeat/rsvp policies, auto-promote flags, and typed invite lookups
- document a shared accelerator/programmer production checklist and record the typed app shell work in the changelog

## Testing
- npm run lint
- npm run test
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3ca5519648325b53502ffdef6d112